### PR TITLE
Remove penumbra-harbor symlink from project root

### DIFF
--- a/penumbra-harbor-20250605-211508
+++ b/penumbra-harbor-20250605-211508
@@ -1,1 +1,0 @@
-/Users/jasonganz/Desktop/penumbra-harbor-20250605-211508


### PR DESCRIPTION
Clean up project directory by removing unused penumbra-harbor symlink.

🤖 Generated with [Claude Code](https://claude.ai/code)